### PR TITLE
Add unhook options for HTML5

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -337,29 +337,33 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
 
 	function html5_entry_hooks_box() {
 
-		simplehooks_form_generate(array(
+		simplehooks_form_generate( array(
 			'hook' => 'genesis_before_entry',
 			'desc' => __( 'This hook executes before each entry in all loop blocks (outside the entry markup element).', 'simplehooks' )
 		) );
 
-		simplehooks_form_generate(array(
+		simplehooks_form_generate( array(
 			'hook' => 'genesis_entry_header',
-			'desc' => __( 'This hook executes before the entry content. By default, it outputs the entry title and meta information.', 'simplehooks' )
+			'desc' => __( 'This hook executes before the entry content. By default, it outputs the entry title and meta information.', 'simplehooks' ),
+			'unhook' => array( 'genesis_do_post_title', array( 'genesis_post_info', 12 ) )
 		) );
 
-		simplehooks_form_generate(array(
+		simplehooks_form_generate( array(
 			'hook' => 'genesis_entry_content',
-			'desc' => __( 'This hook, by default, outputs the entry content.', 'simplehooks' )
+			'desc' => __( 'This hook, by default, outputs the entry content.', 'simplehooks' ),
+			'unhook' => array( array( 'genesis_do_post_image', 8 ), 'genesis_do_post_content' )
 		) );
 
-		simplehooks_form_generate(array(
+		simplehooks_form_generate( array(
 			'hook' => 'genesis_entry_footer',
-			'desc' => __( 'This hook executes after the entry content. By Default, it outputs entry meta information.', 'simplehooks' )
+			'desc' => __( 'This hook executes after the entry content. By Default, it outputs entry meta information.', 'simplehooks' ),
+			'unhook' => array( 'genesis_post_meta' )
 		) );
 
-		simplehooks_form_generate(array(
+		simplehooks_form_generate( array(
 			'hook' => 'genesis_after_entry',
-			'desc' => __( 'This hook executes after each entry in all loop blocks (outside the entry markup element).', 'simplehooks' )
+			'desc' => __( 'This hook executes after each entry in all loop blocks (outside the entry markup element).', 'simplehooks' ),
+			'unhook' => array( array( 'genesis_do_author_box_single', 8 ) )
 		) );
 
 		submit_button( __( 'Save Changes', 'simplehooks' ), 'primary' );
@@ -376,7 +380,7 @@ class Genesis_Simple_Hooks_Admin extends Genesis_Admin_Boxes {
 		simplehooks_form_generate( array(
 			'hook' => 'genesis_after_post',
 			'desc' => __( 'This hook executes after each post in all loop blocks (outside the <code>post_class()</code> div).', 'simplehooks' ),
-			'unhook' => array( 'genesis_do_author_box' )
+			'unhook' => array( 'genesis_do_author_box_single' )
 		) );
 
 		simplehooks_form_generate( array(

--- a/functions.php
+++ b/functions.php
@@ -49,9 +49,17 @@ function simplehooks_form_generate( $args = array() ) {
 		if ( isset( $args['unhook'] ) ) {
 
 			foreach ( (array) $args['unhook'] as $function ) {
+
+				if ( is_array( $function ) ) {
+					$function_name = $function[0];
+					$function = implode( ',', $function );
+				}
+				else {
+					$function_name = $function;
+				}
 			?>
 
-				<input type="checkbox" name="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][unhook][]" id="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][unhook][]" value="<?php echo $function; ?>" <?php if ( in_array( $function, (array) simplehooks_get_option( $args['hook'], 'unhook' ) ) ) echo 'checked'; ?> /> <label for="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][unhook][]"><?php printf( __( 'Unhook <code>%s()</code> function from this hook?', 'simplehooks' ), $function ); ?></label><br />
+				<input type="checkbox" name="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][unhook][]" id="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][unhook][<?php echo $function_name; ?>]" value="<?php echo $function; ?>" <?php if ( in_array( $function, (array) simplehooks_get_option( $args['hook'], 'unhook' ) ) ) echo 'checked'; ?> /> <label for="<?php echo SIMPLEHOOKS_SETTINGS_FIELD; ?>[<?php echo $args['hook']; ?>][unhook][<?php echo $function_name; ?>]"><?php printf( __( 'Unhook <code>%s()</code> function from this hook?', 'simplehooks' ), $function_name ); ?></label><br />
 
 			<?php
 			}

--- a/plugin.php
+++ b/plugin.php
@@ -88,7 +88,13 @@ function simplehooks_execute_hooks() {
 
 			foreach( (array) $array['unhook'] as $function ) {
 
-				remove_action( $hook, $function );
+				$function = explode( ',', $function );
+				if ( !isset( $function[1] ) ) {
+					remove_action( $hook, $function[0] );
+				}
+				else {
+					remove_action( $hook, $function[0], $function[1] );
+				}
 
 			}
 


### PR DESCRIPTION
I discovered that many of the unhook options that are available for XHTML are not available for HTML5, so I added them. It requires some extra code to handle the priorities.

I also updated `genesis_do_author_box` to `genesis_do_author_box_single` and fixed a bug where some labels were matching up with the wrong checkboxes.
