### PR TITLE
Set “Tested up to” to 5.4

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: nathanrice, studiopress
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=5553118
 Tags: hooks, genesis, genesiswp, studiopress
 Requires at least: 4.7.2
-Tested up to: 5.2.2
+Tested up to: 5.4
 Stable tag: 2.3.0
 
 This plugin creates a new Genesis settings page that allows you to insert code (HTML, Shortcodes, and PHP), and attach it to any of the 50+ action hooks throughout the Genesis Theme Framework, from StudioPress.


### PR DESCRIPTION
Tested with WP 5.4 and found no issues.

Readme change only. Could be released without a version bump.